### PR TITLE
fix(tonco-dex): fix critical bugs in swap execution and SDK handling

### DIFF
--- a/plugins/tonco-dex/index.js
+++ b/plugins/tonco-dex/index.js
@@ -46,6 +46,12 @@ let _sdk = null;
 // GraphQL helper
 // ---------------------------------------------------------------------------
 
+/**
+ * Execute a GraphQL query against the TONCO indexer.
+ * @param {string} query - GraphQL query string
+ * @param {object} [variables] - Query variables
+ * @returns {Promise<any>} Parsed response data
+ */
 async function gqlQuery(query, variables = {}) {
   const res = await fetch(INDEXER_URL, {
     method: "POST",
@@ -70,6 +76,11 @@ async function gqlQuery(query, variables = {}) {
 
 let _tonClient = null;
 
+/**
+ * Get or create a TonClient instance.
+ * Uses @orbs-network/ton-access for decentralized endpoints when available.
+ * @returns {Promise<TonClient>}
+ */
 async function getTonClient() {
   if (_tonClient) return _tonClient;
   let endpoint;
@@ -87,6 +98,12 @@ async function getTonClient() {
 // Format helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Format a raw token amount (bigint string) to human-readable decimal.
+ * @param {string|bigint|number} raw - Raw amount in smallest units
+ * @param {number} decimals - Token decimals
+ * @returns {string} Human-readable amount
+ */
 function formatAmount(raw, decimals = 9) {
   if (!raw && raw !== 0n) return "0";
   const s = String(raw);
@@ -97,6 +114,11 @@ function formatAmount(raw, decimals = 9) {
   return fracPart ? `${intPart}.${fracPart}` : intPart;
 }
 
+/**
+ * Format a USD value string for display.
+ * @param {string|number|null} val
+ * @returns {string}
+ */
 function formatUsd(val) {
   if (!val) return "0";
   const n = parseFloat(val);
@@ -106,18 +128,10 @@ function formatUsd(val) {
   return `$${n.toFixed(2)}`;
 }
 
-function parseAmount(amount, decimals = 9) {
-  const str = String(amount);
-  const [intPart, fracPart = ""] = str.split(".");
-  const fracPadded = fracPart.padEnd(decimals, "0").slice(0, decimals);
-  return BigInt(intPart + fracPadded);
-}
-
-// ---------------------------------------------------------------------------
-// Tool 1: tonco_list_pools
-// ---------------------------------------------------------------------------
-
-const toncoListPools = {
-  name: "tonco_list_pools",
-  description:
-    "Discover and list TONCO liquidity pools. Optionally filter
+/**
+ * Parse a human-readable amount to raw bigint units.
+ * @param {string|number} amount - Human-readable amount (e.g. "10.5")
+ * @param {number} decimals - Token decimals
+ * @returns {bigint}
+ */
+function parseAmount(amount, decimals


### PR DESCRIPTION
## 🐛 Critical Bug Fixes for TONCO DEX Plugin

This PR addresses several critical issues that made the plugin non-functional or insecure:

### 🛠 Fixes

1. **`tonco_swap_quote`: Handle missing `ToncoSDK` gracefully**
   - Previously crashed when `@toncodex/sdk` was not installed due to destructuring from `null`.
   - Now checks `if (ToncoSDK)` before using it.
   - Added fallback message explaining SDK requirement.

2. **`tonco_execute_swap`: Correct transaction sending and add security**
   - Replaced incorrect `_sdk.ton.sendTON` with `_sdk.ton.sendMessage` (proper method for contract calls).
   - Added **DM-only restriction** (`context.chatType !== 'private'` returns error).
   - Added **owner check** (only `senderId === _sdk.config.owner_id` can execute swaps).
   - Improved error messages and validation.

3. **`tonco_get_position_fees`: Validate NFT address**
   - Added try-catch around `Address.parse` to handle invalid addresses gracefully.
   - Returns clear error if address is malformed.

4. **Debug logging across all tools**
   - Added `_sdk.log?.debug` at the start of each `execute` to log `context` and `params`.
   - Helps diagnose future issues quickly.

5. **General improvements**
   - Consistent error handling with `slice(0, 500)` truncation.
   - Better messages when SDK is missing.

### 🎯 Impact

- `tonco_swap_quote` now works with or without `@toncodex/sdk` (falls back to price-based estimate).
- `tonco_execute_swap` is now secure (DM + owner only) and uses correct transaction method.
- All tools provide better diagnostics via debug logs.
- Plugin no longer crashes on common error scenarios.

### 🧪 Testing

```bash
# 1. Quote (without SDK)
tonco_swap_quote token_in="TON" token_out="USDT" amount_in="1"

# 2. Quote (with SDK)
# Install: cd ~/.teleton/plugins/tonco-dex && npm install @toncodex/sdk
tonco_swap_quote token_in="TON" token_out="USDT" amount_in="1"

# 3. Execute swap (in DM only, as owner)
tonco_execute_swap token_in="TON" token_out="USDT" amount_in="1" slippage_percent=1.0

# 4. Check logs for debug output
tail -f ~/.teleton/logs/agent.log | grep tonco_
```

### 🔗 Related

- Closes [xlabtg/teleton-plugins#99](https://github.com/xlabtg/teleton-plugins/issues/99)
- Depends on `@toncodex/sdk` for precise quotes and execution (optional but recommended).

---

**Note:** This PR is based on the current `main` branch and includes all critical fixes needed for TONCO DEX to function safely.