### PR TITLE
fix(github-dev-assistant): redact gho_, github_pat_, private keys, and api_key/secret/password in formatError()

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-03-19T10:37:13.073Z for PR creation at branch issue-19-f54b585823d1 for issue https://github.com/xlabtg/teleton-plugins/issues/19
 # Updated: 2026-03-27T01:04:44.761Z
 # Updated: 2026-04-05T19:20:26.278Z
+# Updated: 2026-04-07T11:10:39.237Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-03-19T10:37:13.073Z for PR creation at branch issue-19-f54b585823d1 for issue https://github.com/xlabtg/teleton-plugins/issues/19
 # Updated: 2026-03-27T01:04:44.761Z
 # Updated: 2026-04-05T19:20:26.278Z
-# Updated: 2026-04-07T11:10:39.237Z

--- a/plugins/github-dev-assistant/lib/utils.js
+++ b/plugins/github-dev-assistant/lib/utils.js
@@ -119,7 +119,11 @@ export function formatError(err, fallback = "An unexpected error occurred") {
     .replace(/ghp_[A-Za-z0-9]+/g, "[REDACTED]")
     .replace(/ghs_[A-Za-z0-9]+/g, "[REDACTED]")
     .replace(/ghu_[A-Za-z0-9]+/g, "[REDACTED]")
+    .replace(/gho_[A-Za-z0-9]+/g, "[REDACTED]")
+    .replace(/github_pat_[A-Za-z0-9_]+/g, "[REDACTED]")
     .replace(/Bearer [A-Za-z0-9\-._~+/]+=*/g, "Bearer [REDACTED]")
+    .replace(/-----BEGIN[^-]*PRIVATE KEY-----/g, "[REDACTED PRIVATE KEY]")
+    .replace(/(api_?key|secret|password)\s*[:=]\s*\S+/gi, "$1: [REDACTED]")
     .slice(0, 500);
 }
 

--- a/plugins/github-dev-assistant/tests/format-error.test.js
+++ b/plugins/github-dev-assistant/tests/format-error.test.js
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for formatError() secret redaction.
+ *
+ * Verifies that all known secret patterns are redacted from error messages
+ * before they are returned to callers.
+ *
+ * Uses Node's built-in test runner (node:test). No network access required.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatError } from "../lib/utils.js";
+
+describe("formatError — existing redactions", () => {
+  it("redacts ghp_ tokens", () => {
+    const result = formatError(new Error("token ghp_ABCdef123456 is invalid"));
+    assert.ok(!result.includes("ghp_"), `Expected ghp_ to be redacted, got: ${result}`);
+    assert.ok(result.includes("[REDACTED]"));
+  });
+
+  it("redacts ghs_ tokens", () => {
+    const result = formatError(new Error("server token ghs_XYZabc789 rejected"));
+    assert.ok(!result.includes("ghs_"), `Expected ghs_ to be redacted, got: ${result}`);
+    assert.ok(result.includes("[REDACTED]"));
+  });
+
+  it("redacts ghu_ tokens", () => {
+    const result = formatError(new Error("user token ghu_DEF456 not found"));
+    assert.ok(!result.includes("ghu_"), `Expected ghu_ to be redacted, got: ${result}`);
+    assert.ok(result.includes("[REDACTED]"));
+  });
+
+  it("redacts Bearer tokens", () => {
+    const result = formatError(new Error("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc failed"));
+    assert.ok(!result.includes("eyJhbGciOiJIUzI1NiJ9.abc"), `Expected Bearer token to be redacted, got: ${result}`);
+    assert.ok(result.includes("Bearer [REDACTED]"));
+  });
+});
+
+describe("formatError — OAuth token (gho_)", () => {
+  it("redacts gho_ OAuth App tokens", () => {
+    const result = formatError(new Error("OAuth token gho_OAUTH123abc is expired"));
+    assert.ok(!result.includes("gho_"), `Expected gho_ to be redacted, got: ${result}`);
+    assert.ok(result.includes("[REDACTED]"));
+  });
+});
+
+describe("formatError — fine-grained PAT (github_pat_)", () => {
+  it("redacts github_pat_ fine-grained PATs", () => {
+    const result = formatError(new Error("token github_pat_11ABCDEF_someRandomChars123 is invalid"));
+    assert.ok(!result.includes("github_pat_"), `Expected github_pat_ to be redacted, got: ${result}`);
+    assert.ok(result.includes("[REDACTED]"));
+  });
+});
+
+describe("formatError — private key headers", () => {
+  it("redacts -----BEGIN RSA PRIVATE KEY-----", () => {
+    const result = formatError(new Error("key: -----BEGIN RSA PRIVATE KEY-----\nMIIEo..."));
+    assert.ok(!result.includes("-----BEGIN RSA PRIVATE KEY-----"), `Expected private key header to be redacted, got: ${result}`);
+    assert.ok(result.includes("[REDACTED PRIVATE KEY]"));
+  });
+
+  it("redacts -----BEGIN PRIVATE KEY-----", () => {
+    const result = formatError(new Error("embedded -----BEGIN PRIVATE KEY----- in error"));
+    assert.ok(!result.includes("-----BEGIN PRIVATE KEY-----"), `Expected private key header to be redacted, got: ${result}`);
+    assert.ok(result.includes("[REDACTED PRIVATE KEY]"));
+  });
+});
+
+describe("formatError — generic key/secret/password patterns", () => {
+  it("redacts api_key=<value>", () => {
+    const result = formatError(new Error("request failed: api_key=supersecret123"));
+    assert.ok(!result.includes("supersecret123"), `Expected api_key value to be redacted, got: ${result}`);
+  });
+
+  it("redacts apikey=<value>", () => {
+    const result = formatError(new Error("request failed: apikey=mysecretvalue"));
+    assert.ok(!result.includes("mysecretvalue"), `Expected apikey value to be redacted, got: ${result}`);
+  });
+
+  it("redacts secret=<value>", () => {
+    const result = formatError(new Error("auth error: secret=topsecret99"));
+    assert.ok(!result.includes("topsecret99"), `Expected secret value to be redacted, got: ${result}`);
+  });
+
+  it("redacts password=<value>", () => {
+    const result = formatError(new Error("login failed: password=hunter2"));
+    assert.ok(!result.includes("hunter2"), `Expected password value to be redacted, got: ${result}`);
+  });
+
+  it("redacts SECRET: <value> (colon separator, case-insensitive)", () => {
+    const result = formatError(new Error("SECRET: myTopSecretValue"));
+    assert.ok(!result.includes("myTopSecretValue"), `Expected SECRET value to be redacted, got: ${result}`);
+  });
+});
+
+describe("formatError — safe strings are not over-redacted", () => {
+  it("plain error message is not altered", () => {
+    const result = formatError(new Error("File not found"));
+    assert.equal(result, "File not found");
+  });
+
+  it("undefined err returns fallback", () => {
+    assert.equal(formatError(undefined), "An unexpected error occurred");
+  });
+
+  it("null err returns fallback", () => {
+    assert.equal(formatError(null), "An unexpected error occurred");
+  });
+
+  it("message longer than 500 chars is truncated", () => {
+    const long = "x".repeat(600);
+    const result = formatError(new Error(long));
+    assert.equal(result.length, 500);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes xlabtg/teleton-plugins#117

The \`formatError()\` utility in \`plugins/github-dev-assistant/lib/utils.js\` was missing several secret redaction patterns, which could allow credentials to leak through error messages.

### What was missing

| Pattern | Example | Status before |
|---|---|---|
| \`gho_*\` OAuth App tokens | \`gho_OAUTH123abc\` | ❌ not redacted |
| \`github_pat_*\` fine-grained PATs | \`github_pat_11ABCDEF_...\` | ❌ not redacted |
| PEM private key headers | \`-----BEGIN RSA PRIVATE KEY-----\` | ❌ not redacted |
| \`api_key=\`, \`apikey=\`, \`secret=\`, \`password=\` | \`api_key=supersecret\` | ❌ not redacted |

### Changes

**\`plugins/github-dev-assistant/lib/utils.js\`** — added 4 new \`.replace()\` calls in \`formatError()\`:
- \`/gho_[A-Za-z0-9]+/g\` → \`[REDACTED]\`
- \`/github_pat_[A-Za-z0-9_]+/g\` → \`[REDACTED]\`
- \`/-----BEGIN[^-]*PRIVATE KEY-----/g\` → \`[REDACTED PRIVATE KEY]\`
- \`/(api_?key|secret|password)\s*[:=]\s*\S+/gi\` → \`$1: [REDACTED]\`

**\`plugins/github-dev-assistant/tests/format-error.test.js\`** — new test file with 17 tests covering:
- All existing redaction patterns (regression)
- All 4 new patterns
- Safe strings that must not be over-redacted
- Edge cases: null/undefined input, truncation at 500 chars

### How to reproduce the issue

```js
import { formatError } from "./plugins/github-dev-assistant/lib/utils.js";
// Before fix — these would NOT be redacted:
console.log(formatError(new Error("token gho_OAUTH123abc is invalid")));
// Output: token gho_OAUTH123abc is invalid  ← leaked!
```

### Verification

All 17 new tests pass, and the full suite remains green (0 failures):
```
# tests 251
# pass 231
# fail 0
```

---
*This PR was created automatically by the AI issue solver*